### PR TITLE
Move the port binding of nginx to 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - '80:80'
+      - '8080:80'
     volumes:
       - .:/etc/nginx/
 


### PR DESCRIPTION
I'm running docker using https://github.com/codekitchen/dinghy, which has a built in loadbalancer/proxy image running on 80/443. Running make fails since 80 is already mounted. By moving it to 8080, a less common port (by a small margin), we avoid this problen